### PR TITLE
vCPUEMU: fix apparent minor typo in size of mainmem

### DIFF
--- a/vCPUEMU/main.py
+++ b/vCPUEMU/main.py
@@ -42,7 +42,7 @@ DUMPDISPLAY = True
 
 registers = [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]
 pc = 0
-mainmem = bytearray(65525) # 64K, last 1K (starting at 0xFBFF) for char display
+mainmem = bytearray(0x10000) # 64K, last 1K (starting at 0xFBFF) for char display
 flag_z = 0
 flag_gt = 0
 flag_lt = 0


### PR DESCRIPTION
- size of mainmem was 65525, perhaps a typo for an intended 65536 (2^16)
- proposing 0x10000 for clarity

nice video!